### PR TITLE
use rename options struct instead of bool for rename provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ incompatibilities with those or other servers.
 
 ## Installation
 
-	go get -u github.com/thomasduplessis/acme-lsp/cmd/acme-lsp
-	go get -u github.com/thomasduplessis/acme-lsp/cmd/L
+	go get -u github.com/fhs/acme-lsp/cmd/acme-lsp
+	go get -u github.com/fhs/acme-lsp/cmd/L
 
 ## gopls
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ incompatibilities with those or other servers.
 
 ## Installation
 
-	go get -u github.com/fhs/acme-lsp/cmd/acme-lsp
-	go get -u github.com/fhs/acme-lsp/cmd/L
+	go get -u github.com/thomasduplessis/acme-lsp/cmd/acme-lsp
+	go get -u github.com/thomasduplessis/acme-lsp/cmd/L
 
 ## gopls
 

--- a/internal/lsp/protocol/service.go
+++ b/internal/lsp/protocol/service.go
@@ -181,7 +181,7 @@ type ServerCapabilities struct {
 	DocumentFormattingProvider       bool                             `json:"documentFormattingProvider,omitempty"`
 	DocumentRangeFormattingProvider  bool                             `json:"documentRangeFormattingProvider,omitempty"`
 	DocumentOnTypeFormattingProvider *DocumentOnTypeFormattingOptions `json:"documentOnTypeFormattingProvider,omitempty"`
-	RenameProvider                   bool                             `json:"renameProvider,omitempty"`
+	RenameProvider                   *RenameOptions                   `json:"renameProvider,omitempty"`
 	ExecuteCommandProvider           *ExecuteCommandOptions           `json:"executeCommandProvider,omitempty"`
 
 	/*Workspace defined:
@@ -251,6 +251,10 @@ type ExecuteCommandOptions struct {
 type ExecuteCommandParams struct {
 	Command   string        `json:"command"`
 	Arguments []interface{} `json:"arguments,omitempty"`
+}
+
+type RenameOptions struct {
+	PrepareProvider bool `json:"prepareProvider,omitempty"`
 }
 
 type CompletionItemKind int


### PR DESCRIPTION
Before acme-lsp would not work with lsp servers which provided a RenameOptions instead of a bool.