### PR TITLE
wip: access acme and plumb file systems via Plan 9 syscalls instead of Unix sockets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	9fans.net/go v0.0.0-20181112161441-237454027057
 	github.com/BurntSushi/toml v0.3.1
 	github.com/google/go-cmp v0.3.0
+	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/acme/acme_p9p.go
+++ b/internal/acme/acme_p9p.go
@@ -1,0 +1,18 @@
+// +build !plan9
+
+package acme
+
+import (
+	"9fans.net/go/plan9/client"
+)
+
+func mountAcme() {
+	if Network == "" || Address == "" {
+		panic("network or address not set")
+	}
+	fsys, fsysErr = client.Mount(Network, Address)
+}
+
+func acmefsOpen(name string, mode uint8) (clientFid, error) {
+	return fsys.Open(name, mode)
+}

--- a/internal/acme/acme_plan9.go
+++ b/internal/acme/acme_plan9.go
@@ -1,0 +1,51 @@
+// +build plan9
+
+package acme
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/sys/plan9"
+)
+
+// On Plan 9, the acme file system is already mounted at /mnt/acme if acme is running.
+func mountAcme() {
+	_, fsysErr = os.Stat("/mnt/acme")
+}
+
+// p9fd implements clientFid.
+type p9fd int
+
+func (fd p9fd) Read(b []byte) (n int, err error) {
+	n, err = plan9.Read(int(fd), b)
+	if n == 0 && err == nil {
+		err = io.EOF
+	}
+	return
+}
+
+func (fd p9fd) ReadAt(b []byte, off int64) (n int, err error) {
+	n, err = plan9.Pread(int(fd), b, off)
+	if n == 0 && err == nil {
+		err = io.EOF
+	}
+	return
+}
+
+func (fd p9fd) Write(b []byte) (n int, err error) {
+	return plan9.Write(int(fd), b)
+}
+
+func (fd p9fd) Seek(off int64, whence int) (newoff int64, err error) {
+	return plan9.Seek(int(fd), off, whence)
+}
+
+func (fd p9fd) Close() error {
+	return plan9.Close(int(fd))
+}
+
+func acmefsOpen(name string, mode uint8) (p9fd, error) {
+	fd, err := plan9.Open("/mnt/acme/"+name, int(mode))
+	return p9fd(fd), err
+}

--- a/internal/lsp/acmelsp/acmelsp.go
+++ b/internal/lsp/acmelsp/acmelsp.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"9fans.net/go/plan9"
 	"9fans.net/go/plumb"
 	"github.com/fhs/acme-lsp/internal/acme"
 	"github.com/fhs/acme-lsp/internal/acmeutil"
@@ -79,7 +78,7 @@ func PrintLocations(w io.Writer, loc []protocol.Location) error {
 
 // PlumbLocations sends the locations to the plumber.
 func PlumbLocations(locations []protocol.Location) error {
-	p, err := plumb.Open("send", plan9.OWRITE)
+	p, err := plumbOpenSend()
 	if err != nil {
 		return fmt.Errorf("failed to open plumber: %v", err)
 	}

--- a/internal/lsp/acmelsp/plumb_p9p.go
+++ b/internal/lsp/acmelsp/plumb_p9p.go
@@ -1,0 +1,14 @@
+// +build !plan9
+
+package acmelsp
+
+import (
+	"io"
+
+	"9fans.net/go/plan9"
+	"9fans.net/go/plumb"
+)
+
+func plumbOpenSend() (io.WriteCloser, error) {
+	return plumb.Open("send", plan9.OWRITE)
+}

--- a/internal/lsp/acmelsp/plumb_plan9.go
+++ b/internal/lsp/acmelsp/plumb_plan9.go
@@ -1,0 +1,26 @@
+// +build plan9
+
+package acmelsp
+
+import (
+	"io"
+
+	"golang.org/x/sys/plan9"
+)
+
+// p9fd implements io.WriteCloser.
+type p9fd int
+
+func (fd p9fd) Write(b []byte) (n int, err error) {
+	return plan9.Write(int(fd), b)
+}
+
+func (fd p9fd) Close() error {
+	return plan9.Close(int(fd))
+}
+
+// Cf. /sys/src/libplumb/mesg.c:/^plumbopen/
+func plumbOpenSend() (io.WriteCloser, error) {
+	fd, err := plan9.Open("/mnt/plumb/send", plan9.O_WRONLY)
+	return p9fd(fd), err
+}


### PR DESCRIPTION
See commit messages (maybe I should've opened 2 PRs).

When this works, I may refactor the code into a helper package (for both plumb and acme I implemented a `p9fd` type and there's a little duplication; it's all boilerplate anyway).

Trying it out with `acme-lsp -proxy.addr cirno:3948 -proxy.net tcp -server 'as in README' -workspaces /path/to/wksp`.

Currently stuck at this error:

```
file manager opening acme/log: '/mnt/acme/log' file does not exist
```

on 9front.

(Finding it a little hard to debug as usual tools don't work (e.g. runtime/debug.PrintStack(), CPU profiling to see where it was stuck). Since there's no git I'm actually cross-compiling from the plan9port host also.)