### PR TITLE
no need to set an empty context when completion

### DIFF
--- a/internal/lsp/acmelsp/remote.go
+++ b/internal/lsp/acmelsp/remote.go
@@ -84,7 +84,6 @@ func (rc *RemoteCmd) Completion(ctx context.Context, edit bool) error {
 	}
 	result, err := rc.server.Completion(ctx, &protocol.CompletionParams{
 		TextDocumentPositionParams: *pos,
-		Context:                    &protocol.CompletionContext{},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Tw <tw19881113@gmail.com>