### PR TITLE
Also support single location in Implementation/TypeDefinition/Definition response

### DIFF
--- a/internal/lsp/protocol/compat.go
+++ b/internal/lsp/protocol/compat.go
@@ -67,3 +67,31 @@ func ToCodeActionOptions(v map[string]interface{}) (*CodeActionOptions, error) {
 	}
 	return &opt, nil
 }
+
+// Locations is a type which represents the union of Location and []Location
+type Locations []Location
+
+func (ls *Locations) UnmarshalJSON(data []byte) error {
+	d := strings.TrimSpace(string(data))
+	if len(d) == 0 && strings.EqualFold(d, "null") {
+		return nil
+	}
+
+	if d[0] == '[' {
+		var locations []Location
+		err := json.Unmarshal(data, &locations)
+		if err != nil {
+			return err
+		}
+		*ls = locations
+	} else {
+		var location Location
+		err := json.Unmarshal(data, &location)
+		if err != nil {
+			return err
+		}
+		*ls = append(*ls, location)
+	}
+
+	return nil
+}

--- a/internal/lsp/protocol/tsserver.go
+++ b/internal/lsp/protocol/tsserver.go
@@ -583,7 +583,7 @@ func (s *serverDispatcher) LogTraceNotification(ctx context.Context, params *Log
 	return s.Conn.Notify(ctx, "$/logTraceNotification", params)
 }
 func (s *serverDispatcher) Implementation(ctx context.Context, params *ImplementationParams) ([]Location, error) {
-	var result []Location
+	var result Locations
 	if err := s.Conn.Call(ctx, "textDocument/implementation", params, &result); err != nil {
 		return nil, err
 	}
@@ -591,7 +591,7 @@ func (s *serverDispatcher) Implementation(ctx context.Context, params *Implement
 }
 
 func (s *serverDispatcher) TypeDefinition(ctx context.Context, params *TypeDefinitionParams) ([]Location, error) {
-	var result []Location
+	var result Locations
 	if err := s.Conn.Call(ctx, "textDocument/typeDefinition", params, &result); err != nil {
 		return nil, err
 	}
@@ -691,7 +691,7 @@ func (s *serverDispatcher) SignatureHelp(ctx context.Context, params *SignatureH
 }
 
 func (s *serverDispatcher) Definition(ctx context.Context, params *DefinitionParams) ([]Location, error) {
-	var result []Location
+	var result Locations
 	if err := s.Conn.Call(ctx, "textDocument/definition", params, &result); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
According to the LSP 3.16 spec, in following responses, both `Location` and `[]Location` are allowed:

- [Goto Implementation Request](https://microsoft.github.io/language-server-protocol/specification#textDocument_implementation)
- [Goto Type Definition Request](https://microsoft.github.io/language-server-protocol/specification#textDocument_typeDefinition)
- [Goto Definition Request](https://microsoft.github.io/language-server-protocol/specification#textDocument_definition)

BTW, I encountered this issue when using Zig's language server (zls).

Signed-off-by: Tw <wei.tan@intel.com>