### PR TITLE
Add first completion target with multiple matches

### DIFF
--- a/cmd/L/main.go
+++ b/cmd/L/main.go
@@ -40,10 +40,13 @@ attempt to find the focused window ID by connecting to acmefocused
 
 List of sub-commands:
 
-	comp [-e]
+	comp [-e] [-E]
 		Print candidate completions at the cursor position. If
 		-e (edit) flag is given and there is only one candidate,
-		the completion is applied instead of being printed.
+		the completion is applied instead of being printed. If
+		-E (Edit) flag is given, the first matching candidate is
+		applied, and all matches will be displayed in a dedicated
+		Acme window named /LSP/Completions.
 
 	def [-p]
 		Find where the symbol at the cursor position is defined
@@ -206,7 +209,18 @@ func run(cfg *config.Config, args []string) error {
 	switch args[0] {
 	case "comp":
 		args = args[1:]
-		return rc.Completion(ctx, len(args) > 0 && args[0] == "-e")
+
+		var kind acmelsp.CompletionKind
+		if len(args) > 0 {
+			switch args[0] {
+			case "-e":
+				kind = acmelsp.CompleteInsertOnlyMatch
+			case "-E":
+				kind = acmelsp.CompleteInsertFirstMatch
+			}
+		}
+
+		return rc.Completion(ctx, kind)
 	case "def":
 		args = args[1:]
 		return rc.Definition(ctx, len(args) > 0 && args[0] == "-p")

--- a/cmd/Lone/main.go
+++ b/cmd/Lone/main.go
@@ -142,7 +142,7 @@ func run(cfg *config.Config, args []string) error {
 
 	switch args[0] {
 	case "comp":
-		err = rc.Completion(ctx, false)
+		err = rc.Completion(ctx, acmelsp.CompleteNoEdit)
 	case "def":
 		err = rc.Definition(ctx, false)
 	case "fmt":

--- a/internal/lsp/acmelsp/assist.go
+++ b/internal/lsp/acmelsp/assist.go
@@ -220,7 +220,7 @@ func (w *outputWin) Update(fw *focusWin, server proxy.Server, cmd string) {
 	w.Clear()
 	switch cmd {
 	case "comp":
-		err := rc.Completion(ctx, false)
+		err := rc.Completion(ctx, CompleteNoEdit)
 		if err != nil {
 			dprintf("Completion failed: %v\n", err)
 		}

--- a/internal/lsp/text/edit.go
+++ b/internal/lsp/text/edit.go
@@ -65,6 +65,7 @@ func Edit(f File, edits []protocol.TextEdit) error {
 		q1 := off.LineToOffset(int(e.Range.End.Line), int(e.Range.End.Character))
 		f.WriteAt(q0, q1, []byte(e.NewText))
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
When a completion target has multiple matches, such as when editing Go code that uses generated Protobuf packages that have the same method name at multiple levels of hierarchy, insert the first match always, and display the rest in an Acme window called `/LSP/Completions` similar to `/LSP/Diagnostics`.

This behaviour can be triggered by passing `-E` to `L comp` instead of `-e`. The existing behaviour for `-e` is preserved as is.

Closes #56 