### PR TITLE
ToPath: percent decode input URI

### DIFF
--- a/internal/lsp/text/edit.go
+++ b/internal/lsp/text/edit.go
@@ -4,6 +4,7 @@ package text
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -127,6 +128,7 @@ func ToURI(filename string) protocol.DocumentURI {
 // ToPath converts URI to filename.
 func ToPath(uri protocol.DocumentURI) string {
 	filename, _ := CutPrefix(string(uri), "file://")
+	filename, _ = url.PathUnescape(filename)
 	return filename
 }
 


### PR DESCRIPTION
This is useful in cases where initial path contains special characters.

For example, path containing "c++" needs to be properly decoded, otherwise Acme will try to open file containing %2B%2B, which is wrong.

Partially fixes #60 on GitHub.